### PR TITLE
add additional output

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Available targets:
 | Name | Description |
 |------|-------------|
 | aws\_config\_configuration\_recorder\_id | The ID of the AWS Config Recorder |
+| iam\_role | IAM Role |
 | sns\_topic | SNS topic |
 | sns\_topic\_subscriptions | SNS topic subscriptions |
 | storage\_bucket\_arn | Bucket ARN |

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Available targets:
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | findings\_notification\_arn | The ARN for an SNS topic to send findings notifications to. This is only used if create\_sns\_topic is false.<br>If you want to send findings to an existing SNS topic, set the value of this to the ARN of the existing topic and set <br>create\_sns\_topic to false. | `string` | `null` | no |
 | force\_destroy | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable | `bool` | `false` | no |
-| iam\_role\_arn | The ARN for an IAM Role AWS Config uses to make read or write requests to the delivery channel and to describe the <br>AWS resources associated with the account. This is only used if create\_iam\_role is false.<br><br>If you want to use an existing IAM Role, set the value of this to the ARN of the existing topic and set <br>create\_iam\_role to false. | `string` | `null` | no |
+| iam\_role\_arn | The ARN for an IAM Role AWS Config uses to make read or write requests to the delivery channel and to describe the <br>AWS resources associated with the account. This is only used if create\_iam\_role is false.<br><br>If you want to use an existing IAM Role, set the value of this to the ARN of the existing topic and set <br>create\_iam\_role to false.<br><br>See the AWS Docs for further information: <br>http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html | `string` | `null` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | include\_global\_resource\_types | Flag to indicate whether AWS Config includes all supported types of global resources with the resources that it records | `bool` | `false` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
@@ -159,7 +159,7 @@ Available targets:
 | Name | Description |
 |------|-------------|
 | aws\_config\_configuration\_recorder\_id | The ID of the AWS Config Recorder |
-| iam\_role | IAM Role |
+| iam\_role | IAM Role used to make read or write requests to the delivery channel and to describe the AWS resources associated with <br>the account. |
 | sns\_topic | SNS topic |
 | sns\_topic\_subscriptions | SNS topic subscriptions |
 | storage\_bucket\_arn | Bucket ARN |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -26,7 +26,7 @@
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | findings\_notification\_arn | The ARN for an SNS topic to send findings notifications to. This is only used if create\_sns\_topic is false.<br>If you want to send findings to an existing SNS topic, set the value of this to the ARN of the existing topic and set <br>create\_sns\_topic to false. | `string` | `null` | no |
 | force\_destroy | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable | `bool` | `false` | no |
-| iam\_role\_arn | The ARN for an IAM Role AWS Config uses to make read or write requests to the delivery channel and to describe the <br>AWS resources associated with the account. This is only used if create\_iam\_role is false.<br><br>If you want to use an existing IAM Role, set the value of this to the ARN of the existing topic and set <br>create\_iam\_role to false. | `string` | `null` | no |
+| iam\_role\_arn | The ARN for an IAM Role AWS Config uses to make read or write requests to the delivery channel and to describe the <br>AWS resources associated with the account. This is only used if create\_iam\_role is false.<br><br>If you want to use an existing IAM Role, set the value of this to the ARN of the existing topic and set <br>create\_iam\_role to false.<br><br>See the AWS Docs for further information: <br>http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html | `string` | `null` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | include\_global\_resource\_types | Flag to indicate whether AWS Config includes all supported types of global resources with the resources that it records | `bool` | `false` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
@@ -44,7 +44,7 @@
 | Name | Description |
 |------|-------------|
 | aws\_config\_configuration\_recorder\_id | The ID of the AWS Config Recorder |
-| iam\_role | IAM Role |
+| iam\_role | IAM Role used to make read or write requests to the delivery channel and to describe the AWS resources associated with <br>the account. |
 | sns\_topic | SNS topic |
 | sns\_topic\_subscriptions | SNS topic subscriptions |
 | storage\_bucket\_arn | Bucket ARN |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -44,6 +44,7 @@
 | Name | Description |
 |------|-------------|
 | aws\_config\_configuration\_recorder\_id | The ID of the AWS Config Recorder |
+| iam\_role | IAM Role |
 | sns\_topic | SNS topic |
 | sns\_topic\_subscriptions | SNS topic subscriptions |
 | storage\_bucket\_arn | Bucket ARN |

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -7,3 +7,8 @@ output "storage_bucket_id" {
   value       = module.aws_config.storage_bucket_id
   description = "Bucket Name (aka ID)"
 }
+
+output "iam_role" {
+  description = "IAM Role"
+  value       = module.aws_config.iam_role
+}

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -9,6 +9,9 @@ output "storage_bucket_id" {
 }
 
 output "iam_role" {
-  description = "IAM Role"
+  description = <<-DOC
+  IAM Role used to make read or write requests to the delivery channel and to describe the AWS resources associated with 
+  the account.
+  DOC
   value       = module.aws_config.iam_role
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,7 +14,10 @@ output "storage_bucket_arn" {
 }
 
 output "iam_role" {
-  description = "IAM Role"
+  description = <<-DOC
+  IAM Role used to make read or write requests to the delivery channel and to describe the AWS resources associated with 
+  the account.
+  DOC
   value       = local.create_sns_topic ? module.iam_role[0].arn : var.iam_role_arn
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "storage_bucket_arn" {
   description = "Bucket ARN"
 }
 
+output "iam_role" {
+  description = "IAM Role"
+  value       = local.create_sns_topic ? module.iam_role[0].arn : var.iam_role_arn
+}
+
 output "sns_topic" {
   description = "SNS topic"
   value       = local.create_sns_topic ? module.sns_topic[0].sns_topic : null

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -39,8 +39,10 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	configRecorderID := terraform.Output(t, terraformOptions, "config_recorder_id")
 	bucketID := terraform.Output(t, terraformOptions, "storage_bucket_id")
+	iamRoleArn := terraform.Output(t, terraformOptions, "iam_role")
 
 	// Ensure we get the attribute included in the IDs
 	assert.Equal(t, "eg-ue2-test-config-"+randID, configRecorderID)
 	assert.Equal(t, "eg-ue2-test-aws-config-"+randID, bucketID)
+	assert.NotEqual(t, nil, iamRoleArn)
 }

--- a/test/src/go.sum
+++ b/test/src/go.sum
@@ -197,6 +197,7 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/gruntwork-io/gruntwork-cli v0.7.0/go.mod h1:jp6Z7NcLF2avpY8v71fBx6hds9eOFPELSuD/VPv7w00=
 github.com/gruntwork-io/terratest v0.30.23 h1:9iGmn2kL9hnchriqtSm66BGK67pYJl6SU4iOIjfD9f8=
 github.com/gruntwork-io/terratest v0.30.23/go.mod h1:EEgJie28gX/4AD71IFqgMj6e99KP5mi81hEtzmDjxTo=
+github.com/gruntwork-io/terratest v0.31.1 h1:MPGe/5pGgJAIZ/hb+0LM1KyJKSi/QyxSkHoP9/CBhJg=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
@@ -315,6 +316,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,9 @@ variable "iam_role_arn" {
   
     If you want to use an existing IAM Role, set the value of this to the ARN of the existing topic and set 
     create_iam_role to false.
+    
+    See the AWS Docs for further information: 
+    http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html
   DOC
   default     = null
   type        = string


### PR DESCRIPTION
## what
* add the `iam_role` that was created or passed in as an output to the module

## why
* allows the caller to reference the IAM role in other modules