### PR TITLE
conformance-pack module fix for hardcoded name of resource

### DIFF
--- a/examples/hipaa/main.tf
+++ b/examples/hipaa/main.tf
@@ -28,6 +28,7 @@ module "aws_config" {
 module "hipaa_conformance_pack" {
   source  = "../../modules/conformance-pack"
   context = module.this.context
+  name    = "operational-best-practices-for-HIPAA-Security"
 
   conformance_pack = "https://raw.githubusercontent.com/awslabs/aws-config-rules/master/aws-config-conformance-packs/Operational-Best-Practices-for-HIPAA-Security.yaml"
   parameter_overrides = {

--- a/modules/conformance-pack/README.md
+++ b/modules/conformance-pack/README.md
@@ -19,6 +19,8 @@ module "hipaa_conformance_pack" {
   # Cloud Posse recommends pinning every module to a specific version
   # version     = "x.x.x"
 
+  name = "Operational-Best-Practices-for-HIPAA-Security"
+
   conformance_pack="https://raw.githubusercontent.com/awslabs/aws-config-rules/master/aws-config-conformance-packs/Operational-Best-Practices-for-HIPAA-Security.yaml"
   parameter_overrides = {
     AccessKeysRotatedParamMaxAccessKeyAge = "45"

--- a/modules/conformance-pack/main.tf
+++ b/modules/conformance-pack/main.tf
@@ -1,5 +1,5 @@
-resource "aws_config_conformance_pack" "hipaa" {
-  name = "operational-best-practices-for-HIPAA-Security"
+resource "aws_config_conformance_pack" "default" {
+  name = module.this.name
 
   dynamic "input_parameter" {
     for_each = var.parameter_overrides

--- a/modules/conformance-pack/outputs.tf
+++ b/modules/conformance-pack/outputs.tf
@@ -1,3 +1,3 @@
 output "arn" {
-  value = aws_config_conformance_pack.hipaa.arn
+  value = aws_config_conformance_pack.default.arn
 }


### PR DESCRIPTION
## what
* hardcoded name of resource fixed to use `name` from context

## why
* conformance-pack module already build as unified module to apply any available AWS conformance packs, the only thing left is to set custom names 
