### PR TITLE
IAM role fails to create without SNS topic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,10 +96,10 @@ module "iam_role" {
 
   policy_documents = [
     data.aws_iam_policy_document.config_s3_policy[0].json,
-    data.aws_iam_policy_document.config_sns_policy[0].json
+    var.create_sns_topic ? data.aws_iam_policy_document.config_sns_policy[0].json : null
   ]
 
-  policy_document_count = 2
+  policy_document_count = var.create_sns_topic ? 2 : 1
   policy_description    = "AWS Config IAM policy"
   role_description      = "AWS Config IAM role"
 

--- a/main.tf
+++ b/main.tf
@@ -94,9 +94,11 @@ module "iam_role" {
 
   use_fullname = true
 
-  policy_documents = [
+  policy_documents = var.create_sns_topic ? [
     data.aws_iam_policy_document.config_s3_policy[0].json,
-    var.create_sns_topic ? data.aws_iam_policy_document.config_sns_policy[0].json : null
+    data.aws_iam_policy_document.config_sns_policy[0].json
+  ] : [
+    data.aws_iam_policy_document.config_s3_policy[0].json
   ]
 
   policy_document_count = var.create_sns_topic ? 2 : 1

--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ module "iam_role" {
   policy_documents = var.create_sns_topic ? [
     data.aws_iam_policy_document.config_s3_policy[0].json,
     data.aws_iam_policy_document.config_sns_policy[0].json
-  ] : [
+    ] : [
     data.aws_iam_policy_document.config_s3_policy[0].json
   ]
 


### PR DESCRIPTION
## what
* The IAM role for putting objects into S3 can only be created if `create_sns_topic` is true, because the data object on line 144 depends on it, and the IAM role currently needs this data object

## why
* I was unable to instantiate this module with both `create_sns_topic = false` and `create_iam_role = true`

## references
* main.tf lines 99, 145
