### PR TITLE
Fix subscriber input variable handler

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ module "sns_topic" {
 
   attributes = concat(module.this.attributes, ["config"])
   subscribers = {
-    for subscriber in var.subscribers : subscriber => {
+    for key, subscriber in var.subscribers : key => {
       protocol               = lookup(subscriber, "protocol")
       endpoint               = lookup(subscriber, "endpoint")
       endpoint_auto_confirms = lookup(subscriber, "endpoint_auto_confirms", false)


### PR DESCRIPTION
## what
Adds a valid key of type string for sns subscriber handler

## why
A recent commit adds defaults to subscriber input but also breaks any input on map key type:
![image](https://user-images.githubusercontent.com/22661159/146816907-d6f62bac-9a20-40bc-a32a-fc425aa27877.png)

Proposed fix tested with following input, pulled from cloudposse/terraform-aws-sns-topic:
```bash
locals {
  subscribers = {
    opsgenie = {
      protocol = "https"
      endpoint = "https://api.example.com/v1/"
      endpoint_auto_confirms = true
    }
  }
}

module "test" {
  source = "../terraform-aws-config"
  # Cloud Posse recommends pinning every module to a specific version
  # version     = "x.x.x"

  create_sns_topic = true
  create_iam_role  = true

  subscribers = local.subscribers
}
```

## thanks
Thank you for these modules! ❤

