### PR TITLE
Enable tags for resources

### DIFF
--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Create Pull Request
       if: steps.update.outputs.create_pull_request == 'true'
-      uses: cloudposse/actions/github/create-pull-request@0.22.0
+      uses: cloudposse/actions/github/create-pull-request@0.30.0
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
         committer: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -62,7 +62,7 @@ jobs:
         fi
 
     - name: Auto Test
-      uses: cloudposse/actions/github/repository-dispatch@0.22.0
+      uses: cloudposse/actions/github/repository-dispatch@0.30.0
       # match users by ID because logins (user names) are inconsistent,
       # for example in the REST API Renovate Bot is `renovate[bot]` but
       # in GraphQL it is just `renovate`, plus there is a non-bot

--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -1,0 +1,71 @@
+name: "auto-readme"
+on:
+  workflow_dispatch:
+
+  schedule:
+  # Example of job definition:
+  # .---------------- minute (0 - 59)
+  # |  .------------- hour (0 - 23)
+  # |  |  .---------- day of month (1 - 31)
+  # |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+  # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+  # |  |  |  |  |
+  # *  *  *  *  * user-name command to be executed
+
+  # Update README.md nightly at 4am UTC
+  - cron:  '0 4 * * *'
+
+jobs:
+  update:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Find default branch name
+      id: defaultBranch
+      shell: bash
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+        printf "::set-output name=defaultBranch::%s\n" "${default_branch}"
+        printf "defaultBranchRef.name=%s\n" "${default_branch}"
+
+    - name: Update readme
+      shell: bash
+      id: update
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        DEF: "${{ steps.defaultBranch.outputs.defaultBranch }}"
+      run: |
+        make init
+        make readme/build
+        # Ignore changes if they are only whitespace
+        if ! git diff --quiet README.md && git diff --ignore-all-space --ignore-blank-lines --quiet README.md; then
+          git restore README.md
+          echo Ignoring whitespace-only changes in README
+        fi
+
+    - name: Create Pull Request
+      # This action will not create or change a pull request if there are no changes to make.
+      # If a PR of the auto-update/readme branch is open, this action will just update it, not create a new PR.
+      uses: cloudposse/actions/github/create-pull-request@0.30.0
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        commit-message: Update README.md and docs
+        title: Update README.md and docs
+        body: |-
+          ## what
+          This is an auto-generated PR that updates the README.md and docs
+
+          ## why
+          To have most recent changes of README.md and doc from origin templates
+
+        branch: auto-update/readme
+        base: ${{ steps.defaultBranch.outputs.defaultBranch }}
+        delete-branch: true
+        labels: |
+          auto-update
+          no-release
+          readme

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "Handle common commands"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.22.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
       - name: "Checkout commit"
         uses: actions/checkout@v2
       - name: "Run tests"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.22.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
-    - uses: mszostok/codeowners-validator@v0.5.0
+    - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"
       with:
@@ -18,10 +18,12 @@ jobs:
         # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
         #   checks: "files,syntax,owners,duppatterns"
         checks: "syntax,owners,duppatterns"
+        owner_checker_allow_unowned_patterns: "false"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
-    - uses: mszostok/codeowners-validator@v0.5.0
+    - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"
       with:
         checks: "syntax,duppatterns"
+        owner_checker_allow_unowned_patterns: "false"

--- a/main.tf
+++ b/main.tf
@@ -189,7 +189,8 @@ resource "aws_config_configuration_aggregator" "this" {
     account_ids = local.child_resource_collector_accounts
     all_regions = true
   }
-  tags = var.tags
+
+  tags = module.this.tags
 }
 
 resource "aws_config_aggregate_authorization" "child" {
@@ -202,7 +203,8 @@ resource "aws_config_aggregate_authorization" "child" {
 
   account_id = var.central_resource_collector_account
   region     = var.global_resource_collector_region
-  tags       = var.tags
+
+  tags = module.this.tags
 }
 
 resource "aws_config_aggregate_authorization" "central" {
@@ -214,7 +216,8 @@ resource "aws_config_aggregate_authorization" "central" {
 
   account_id = data.aws_caller_identity.this.account_id
   region     = var.global_resource_collector_region
-  tags       = var.tags
+
+  tags = module.this.tags
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -189,6 +189,7 @@ resource "aws_config_configuration_aggregator" "this" {
     account_ids = local.child_resource_collector_accounts
     all_regions = true
   }
+  tags = var.tags
 }
 
 resource "aws_config_aggregate_authorization" "child" {
@@ -201,6 +202,7 @@ resource "aws_config_aggregate_authorization" "child" {
 
   account_id = var.central_resource_collector_account
   region     = var.global_resource_collector_region
+  tags = var.tags
 }
 
 resource "aws_config_aggregate_authorization" "central" {
@@ -212,6 +214,7 @@ resource "aws_config_aggregate_authorization" "central" {
 
   account_id = data.aws_caller_identity.this.account_id
   region     = var.global_resource_collector_region
+  tags = var.tags
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -202,7 +202,7 @@ resource "aws_config_aggregate_authorization" "child" {
 
   account_id = var.central_resource_collector_account
   region     = var.global_resource_collector_region
-  tags = var.tags
+  tags       = var.tags
 }
 
 resource "aws_config_aggregate_authorization" "central" {
@@ -214,7 +214,7 @@ resource "aws_config_aggregate_authorization" "central" {
 
   account_id = data.aws_caller_identity.this.account_id
   region     = var.global_resource_collector_region
-  tags = var.tags
+  tags       = var.tags
 }
 
 


### PR DESCRIPTION
## what
implement a map(string) variable called tags and ensure this is implemented for:

- The 'aws_config_configuration_aggregator' resource with 'this' resource name
- The 'aws_config_aggregate_authorization' resource with 'child' resource name
- The ' aws_config_aggregate_authorization' resource with 'central' resource name

## why
When we began using the repo, we found that some of the resource are yet to be tag enabled. Hence when our internal projects were calling this repo, our custom tags were not being added in AWS. 

## references
* Closes https://github.com/cloudposse/terraform-aws-config/issues/50
