### PR TITLE
Add Filtering of Recorded ResourceTypes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,8 +14,9 @@ resource "aws_config_configuration_recorder" "recorder" {
   name     = module.aws_config_label.id
   role_arn = local.create_iam_role ? module.iam_role[0].arn : var.iam_role_arn
   recording_group {
-    all_supported                 = true
-    include_global_resource_types = local.is_global_recorder_region
+    all_supported                 = (length(var.recorded_resource_types) == 0) ? true : false
+    include_global_resource_types = (length(var.recorded_resource_types) == 0) ? local.is_global_recorder_region : null
+    resource_types                = var.recorded_resource_types
   }
 }
 
@@ -231,7 +232,7 @@ data "aws_region" "this" {}
 data "aws_caller_identity" "this" {}
 
 locals {
-  enabled = module.this.enabled && ! contains(var.disabled_aggregation_regions, data.aws_region.this.name)
+  enabled = module.this.enabled && !contains(var.disabled_aggregation_regions, data.aws_region.this.name)
 
   is_central_account                = var.central_resource_collector_account == data.aws_caller_identity.this.account_id
   is_global_recorder_region         = var.global_resource_collector_region == data.aws_region.this.name

--- a/variables.tf
+++ b/variables.tf
@@ -158,3 +158,9 @@ variable "allowed_iam_arns_for_sns_publish" {
   default     = []
 }
 
+# https://docs.aws.amazon.com/config/latest/APIReference/API_ResourceIdentifier.html#config-Type-ResourceIdentifier-resourceType
+variable "recorded_resource_types" {
+  type        = list(string)
+  description = "An allowlist of which evaluations to save as records."
+  default     = []
+}


### PR DESCRIPTION
## what
This commit adds a new optional variable.  Not setting it defaults to the original/current behaviour.

Setting `recorded_resource_types` will configure an allowlist of which items will be recorded.  Configuration Items found by the rules, but not associated to these resourceTypes will be dropped.

## why
AWS Config pricing relies on two axis: rule-evaluation and configuration-item-recorded.  Allowing filtering of which resourceTypes are to be recorded enables a mechanism to control costs.


## references
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_recorder#recording_group
- https://docs.aws.amazon.com/config/latest/APIReference/API_ResourceIdentifier.html#config-Type-ResourceIdentifier-resourceType