### PR TITLE
Propose adding support organization aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.58.0 |
 
 ## Modules
 
@@ -162,6 +162,7 @@ Available targets:
 | <a name="module_aws_config_findings_label"></a> [aws\_config\_findings\_label](#module\_aws\_config\_findings\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_aws_config_label"></a> [aws\_config\_label](#module\_aws\_config\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_iam_role"></a> [iam\_role](#module\_iam\_role) | cloudposse/iam-role/aws | 0.15.0 |
+| <a name="module_iam_role_organization_aggregator"></a> [iam\_role\_organization\_aggregator](#module\_iam\_role\_organization\_aggregator) | cloudposse/iam-role/aws | 0.9.3 |
 | <a name="module_sns_topic"></a> [sns\_topic](#module\_sns\_topic) | cloudposse/sns-topic/aws | 0.20.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
@@ -176,11 +177,14 @@ Available targets:
 | [aws_config_configuration_recorder.recorder](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_recorder) | resource |
 | [aws_config_configuration_recorder_status.recorder_status](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_recorder_status) | resource |
 | [aws_config_delivery_channel.channel](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_delivery_channel) | resource |
+| [aws_iam_role_policy_attachment.config_organization_aggregator_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.config_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy.aws_config_built_in_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_policy.aws_config_built_in_role_for_organizations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.config_s3_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.config_sns_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
@@ -188,13 +192,14 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_aggregate_organization_wide"></a> [aggregate\_organization\_wide](#input\_aggregate\_organization\_wide) | Whether to configure the central account Aggregator organization-wide,<br>using an organization\_aggregation\_source block.<br>Setting this to true will<br>- Create an Aggregator (if we're in the AWS Config central account)<br>- Create an IAM role for the aggregation with attached AWS-managed policy arn:aws:iam::aws:policy/service-role/AWSConfigRoleForOrganizations<br>- Enable aggregation for all regions<br>- Create an organization\_aggregation\_source block instead of an account\_aggregation\_source one<br>Note only one of aggregate\_organization\_wide or child\_resource\_collector\_accounts should be set.<br>See:<br>https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_aggregator#organization_aggregation_source | `bool` | `false` | no |
 | <a name="input_allowed_aws_services_for_sns_published"></a> [allowed\_aws\_services\_for\_sns\_published](#input\_allowed\_aws\_services\_for\_sns\_published) | AWS services that will have permission to publish to SNS topic. Used when no external JSON policy is used | `list(string)` | `[]` | no |
 | <a name="input_allowed_iam_arns_for_sns_publish"></a> [allowed\_iam\_arns\_for\_sns\_publish](#input\_allowed\_iam\_arns\_for\_sns\_publish) | IAM role/user ARNs that will have permission to publish to SNS topic. Used when no external json policy is used. | `list(string)` | `[]` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_central_resource_collector_account"></a> [central\_resource\_collector\_account](#input\_central\_resource\_collector\_account) | The account ID of a central account that will aggregate AWS Config from other accounts | `string` | `null` | no |
 | <a name="input_child_resource_collector_accounts"></a> [child\_resource\_collector\_accounts](#input\_child\_resource\_collector\_accounts) | The account IDs of other accounts that will send their AWS Configuration to this account | `set(string)` | `null` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
-| <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Flag to indicate whether an IAM Role should be created to grant the proper permissions for AWS Config | `bool` | `false` | no |
+| <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Flag to indicate whether an IAM Role should be created to grant the proper permissions for AWS Config (affects creation of both the standard Config role, as well as the Organization-wide Aggregator Role (if in use). | `bool` | `false` | no |
 | <a name="input_create_sns_topic"></a> [create\_sns\_topic](#input\_create\_sns\_topic) | Flag to indicate whether an SNS topic should be created for notifications<br>If you want to send findings to a new SNS topic, set this to true and provide a valid configuration for subscribers | `bool` | `false` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
@@ -205,6 +210,7 @@ Available targets:
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable | `bool` | `false` | no |
 | <a name="input_global_resource_collector_region"></a> [global\_resource\_collector\_region](#input\_global\_resource\_collector\_region) | The region that collects AWS Config data for global resources such as IAM | `string` | n/a | yes |
 | <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | The ARN for an IAM Role AWS Config uses to make read or write requests to the delivery channel and to describe the<br>AWS resources associated with the account. This is only used if create\_iam\_role is false.<br><br>If you want to use an existing IAM Role, set the value of this to the ARN of the existing topic and set<br>create\_iam\_role to false.<br><br>See the AWS Docs for further information:<br>http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html | `string` | `null` | no |
+| <a name="input_iam_role_organization_aggregator_arn"></a> [iam\_role\_organization\_aggregator\_arn](#input\_iam\_role\_organization\_aggregator\_arn) | The ARN for an IAM Role the Aggregator uses to read organization data<br>Should have the AWS-managed policy attached arn:aws:iam::aws:policy/service-role/AWSConfigRoleForOrganizations<br>This is only used if create\_iam\_role is false.<br>If you want to use an existing IAM Role, set the value of this to the ARN of the existing role and set<br>create\_iam\_role to false.<br>See the AWS Docs for further information:<br>http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html | `string` | `null` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
@@ -230,6 +236,7 @@ Available targets:
 |------|-------------|
 | <a name="output_aws_config_configuration_recorder_id"></a> [aws\_config\_configuration\_recorder\_id](#output\_aws\_config\_configuration\_recorder\_id) | The ID of the AWS Config Recorder |
 | <a name="output_iam_role"></a> [iam\_role](#output\_iam\_role) | IAM Role used to make read or write requests to the delivery channel and to describe the AWS resources associated with <br>the account. |
+| <a name="output_iam_role_organization_aggregator_arn"></a> [iam\_role\_organization\_aggregator\_arn](#output\_iam\_role\_organization\_aggregator\_arn) | IAM Role the Aggregator uses to read organization data |
 | <a name="output_sns_topic"></a> [sns\_topic](#output\_sns\_topic) | SNS topic |
 | <a name="output_sns_topic_subscriptions"></a> [sns\_topic\_subscriptions](#output\_sns\_topic\_subscriptions) | SNS topic subscriptions |
 | <a name="output_storage_bucket_arn"></a> [storage\_bucket\_arn](#output\_storage\_bucket\_arn) | Bucket ARN |
@@ -335,7 +342,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2021-2022 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2021-2023 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.58.0 |
 
 ## Modules
 
@@ -20,6 +20,7 @@
 | <a name="module_aws_config_findings_label"></a> [aws\_config\_findings\_label](#module\_aws\_config\_findings\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_aws_config_label"></a> [aws\_config\_label](#module\_aws\_config\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_iam_role"></a> [iam\_role](#module\_iam\_role) | cloudposse/iam-role/aws | 0.15.0 |
+| <a name="module_iam_role_organization_aggregator"></a> [iam\_role\_organization\_aggregator](#module\_iam\_role\_organization\_aggregator) | cloudposse/iam-role/aws | 0.9.3 |
 | <a name="module_sns_topic"></a> [sns\_topic](#module\_sns\_topic) | cloudposse/sns-topic/aws | 0.20.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
@@ -34,11 +35,14 @@
 | [aws_config_configuration_recorder.recorder](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_recorder) | resource |
 | [aws_config_configuration_recorder_status.recorder_status](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_recorder_status) | resource |
 | [aws_config_delivery_channel.channel](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_delivery_channel) | resource |
+| [aws_iam_role_policy_attachment.config_organization_aggregator_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.config_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy.aws_config_built_in_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_policy.aws_config_built_in_role_for_organizations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.config_s3_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.config_sns_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
@@ -46,13 +50,14 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_aggregate_organization_wide"></a> [aggregate\_organization\_wide](#input\_aggregate\_organization\_wide) | Whether to configure the central account Aggregator organization-wide,<br>using an organization\_aggregation\_source block.<br>Setting this to true will<br>- Create an Aggregator (if we're in the AWS Config central account)<br>- Create an IAM role for the aggregation with attached AWS-managed policy arn:aws:iam::aws:policy/service-role/AWSConfigRoleForOrganizations<br>- Enable aggregation for all regions<br>- Create an organization\_aggregation\_source block instead of an account\_aggregation\_source one<br>Note only one of aggregate\_organization\_wide or child\_resource\_collector\_accounts should be set.<br>See:<br>https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_aggregator#organization_aggregation_source | `bool` | `false` | no |
 | <a name="input_allowed_aws_services_for_sns_published"></a> [allowed\_aws\_services\_for\_sns\_published](#input\_allowed\_aws\_services\_for\_sns\_published) | AWS services that will have permission to publish to SNS topic. Used when no external JSON policy is used | `list(string)` | `[]` | no |
 | <a name="input_allowed_iam_arns_for_sns_publish"></a> [allowed\_iam\_arns\_for\_sns\_publish](#input\_allowed\_iam\_arns\_for\_sns\_publish) | IAM role/user ARNs that will have permission to publish to SNS topic. Used when no external json policy is used. | `list(string)` | `[]` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_central_resource_collector_account"></a> [central\_resource\_collector\_account](#input\_central\_resource\_collector\_account) | The account ID of a central account that will aggregate AWS Config from other accounts | `string` | `null` | no |
 | <a name="input_child_resource_collector_accounts"></a> [child\_resource\_collector\_accounts](#input\_child\_resource\_collector\_accounts) | The account IDs of other accounts that will send their AWS Configuration to this account | `set(string)` | `null` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
-| <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Flag to indicate whether an IAM Role should be created to grant the proper permissions for AWS Config | `bool` | `false` | no |
+| <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Flag to indicate whether an IAM Role should be created to grant the proper permissions for AWS Config (affects creation of both the standard Config role, as well as the Organization-wide Aggregator Role (if in use). | `bool` | `false` | no |
 | <a name="input_create_sns_topic"></a> [create\_sns\_topic](#input\_create\_sns\_topic) | Flag to indicate whether an SNS topic should be created for notifications<br>If you want to send findings to a new SNS topic, set this to true and provide a valid configuration for subscribers | `bool` | `false` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
@@ -63,6 +68,7 @@
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable | `bool` | `false` | no |
 | <a name="input_global_resource_collector_region"></a> [global\_resource\_collector\_region](#input\_global\_resource\_collector\_region) | The region that collects AWS Config data for global resources such as IAM | `string` | n/a | yes |
 | <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | The ARN for an IAM Role AWS Config uses to make read or write requests to the delivery channel and to describe the<br>AWS resources associated with the account. This is only used if create\_iam\_role is false.<br><br>If you want to use an existing IAM Role, set the value of this to the ARN of the existing topic and set<br>create\_iam\_role to false.<br><br>See the AWS Docs for further information:<br>http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html | `string` | `null` | no |
+| <a name="input_iam_role_organization_aggregator_arn"></a> [iam\_role\_organization\_aggregator\_arn](#input\_iam\_role\_organization\_aggregator\_arn) | The ARN for an IAM Role the Aggregator uses to read organization data<br>Should have the AWS-managed policy attached arn:aws:iam::aws:policy/service-role/AWSConfigRoleForOrganizations<br>This is only used if create\_iam\_role is false.<br>If you want to use an existing IAM Role, set the value of this to the ARN of the existing role and set<br>create\_iam\_role to false.<br>See the AWS Docs for further information:<br>http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html | `string` | `null` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
@@ -88,6 +94,7 @@
 |------|-------------|
 | <a name="output_aws_config_configuration_recorder_id"></a> [aws\_config\_configuration\_recorder\_id](#output\_aws\_config\_configuration\_recorder\_id) | The ID of the AWS Config Recorder |
 | <a name="output_iam_role"></a> [iam\_role](#output\_iam\_role) | IAM Role used to make read or write requests to the delivery channel and to describe the AWS resources associated with <br>the account. |
+| <a name="output_iam_role_organization_aggregator_arn"></a> [iam\_role\_organization\_aggregator\_arn](#output\_iam\_role\_organization\_aggregator\_arn) | IAM Role the Aggregator uses to read organization data |
 | <a name="output_sns_topic"></a> [sns\_topic](#output\_sns\_topic) | SNS topic |
 | <a name="output_sns_topic_subscriptions"></a> [sns\_topic\_subscriptions](#output\_sns\_topic\_subscriptions) | SNS topic subscriptions |
 | <a name="output_storage_bucket_arn"></a> [storage\_bucket\_arn](#output\_storage\_bucket\_arn) | Bucket ARN |

--- a/main.tf
+++ b/main.tf
@@ -278,7 +278,7 @@ data "aws_region" "this" {}
 data "aws_caller_identity" "this" {}
 
 locals {
-  enabled = module.this.enabled && ! contains(var.disabled_aggregation_regions, data.aws_region.this.name)
+  enabled = module.this.enabled && !contains(var.disabled_aggregation_regions, data.aws_region.this.name)
 
   is_central_account                = var.central_resource_collector_account == data.aws_caller_identity.this.account_id
   is_global_recorder_region         = var.global_resource_collector_region == data.aws_region.this.name

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,6 +21,11 @@ output "iam_role" {
   value       = local.create_iam_role ? module.iam_role[0].arn : var.iam_role_arn
 }
 
+output "iam_role_organization_aggregator_arn" {
+  description = "IAM Role the Aggregator uses to read organization data"
+  value       = local.create_iam_role && var.aggregate_organization_wide ? module.iam_role_organization_aggregator[0].arn : var.iam_role_organization_aggregator_arn
+}
+
 output "sns_topic" {
   description = "SNS topic"
   value       = local.create_sns_topic ? module.sns_topic[0].sns_topic : null

--- a/variables.tf
+++ b/variables.tf
@@ -64,7 +64,9 @@ variable "findings_notification_arn" {
 
 
 variable "create_iam_role" {
-  description = "Flag to indicate whether an IAM Role should be created to grant the proper permissions for AWS Config"
+  description = <<-DOC
+    Flag to indicate whether an IAM Role should be created to grant the proper permissions for AWS Config (affects creation of both the standard Config role, as well as the Organization-wide Aggregator Role (if in use).
+    DOC
   type        = bool
   default     = false
 }
@@ -93,6 +95,37 @@ variable "central_resource_collector_account" {
   description = "The account ID of a central account that will aggregate AWS Config from other accounts"
   type        = string
   default     = null
+}
+
+variable "iam_role_organization_aggregator_arn" {
+  description = <<-DOC
+    The ARN for an IAM Role the Aggregator uses to read organization data
+    Should have the AWS-managed policy attached arn:aws:iam::aws:policy/service-role/AWSConfigRoleForOrganizations
+    This is only used if create_iam_role is false.
+    If you want to use an existing IAM Role, set the value of this to the ARN of the existing role and set
+    create_iam_role to false.
+    See the AWS Docs for further information:
+    http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html
+  DOC
+  default     = null
+  type        = string
+}
+
+variable "aggregate_organization_wide" {
+  description = <<-DOC
+    Whether to configure the central account Aggregator organization-wide,
+    using an organization_aggregation_source block.
+    Setting this to true will
+    - Create an Aggregator (if we're in the AWS Config central account)
+    - Create an IAM role for the aggregation with attached AWS-managed policy arn:aws:iam::aws:policy/service-role/AWSConfigRoleForOrganizations
+    - Enable aggregation for all regions
+    - Create an organization_aggregation_source block instead of an account_aggregation_source one
+    Note only one of aggregate_organization_wide or child_resource_collector_accounts should be set.
+    See:
+    https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_aggregator#organization_aggregation_source
+  DOC
+  type        = bool
+  default     = false
 }
 
 variable "child_resource_collector_accounts" {


### PR DESCRIPTION
## what
* Support AWS Config Aggregator being created to aggregate Org-wide (vs. fixed list of accounts)
* Optional IAM Role creation to support such, or can pass in (same as existing "iam_role" functionality)

## why
* Make it easy to create Aggregator for all accounts (including newly-created ones)

## references
* Here we adding AWS ORG aggregator authorization using the same approach that "rdkls" proposed in his PR on 2021, and change some little things.
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_aggregator#organization_aggregation_source
* https://github.com/rdkls/terraform-aws-config/tree/support_organization_wide_aggregator