### PR TITLE
Support AWS Provider V5

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'examples/**'
       - 'test/**'
+      - 'README.*'
 
 permissions:
   contents: write

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-published.yml@main

--- a/README.md
+++ b/README.md
@@ -145,14 +145,14 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,14 +3,14 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/examples/cis/main.tf
+++ b/examples/cis/main.tf
@@ -66,7 +66,7 @@ module "cis_rules" {
 
 module "aws_config_storage" {
   source  = "cloudposse/config-storage/aws"
-  version = "0.1.0"
+  version = "1.0.0"
 
   force_destroy = var.force_destroy
   tags          = module.this.tags

--- a/examples/cis/versions.tf
+++ b/examples/cis/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "aws_config_storage" {
   source  = "cloudposse/config-storage/aws"
-  version = "0.1.0"
+  version = "1.0.0"
 
   force_destroy = var.force_destroy
   tags          = module.this.tags

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.0"
 
   required_providers {
     local = {
@@ -8,7 +8,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2"
+      version = ">= 5.0"
     }
   }
 }

--- a/examples/hipaa/main.tf
+++ b/examples/hipaa/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "aws_config_storage" {
   source  = "cloudposse/config-storage/aws"
-  version = "0.4.0"
+  version = "1.0.0"
 
   force_destroy = var.force_destroy
   tags          = module.this.tags

--- a/examples/hipaa/versions.tf
+++ b/examples/hipaa/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -231,7 +231,7 @@ data "aws_region" "this" {}
 data "aws_caller_identity" "this" {}
 
 locals {
-  enabled = module.this.enabled && ! contains(var.disabled_aggregation_regions, data.aws_region.this.name)
+  enabled = module.this.enabled && !contains(var.disabled_aggregation_regions, data.aws_region.this.name)
 
   is_central_account                = var.central_resource_collector_account == data.aws_caller_identity.this.account_id
   is_global_recorder_region         = var.global_resource_collector_region == data.aws_region.this.name

--- a/modules/cis-1-2-rules/main.tf
+++ b/modules/cis-1-2-rules/main.tf
@@ -10,9 +10,9 @@ locals {
   region_exclusion_tag    = "region/excluded/${local.current_region}"
 
   tagged_rules          = { for key, rule in local.rules_with_tags : key => rule if lookup(rule.tags, local.compliance_standard_tag, false) == true }
-  logging_account_rules = { for key, rule in local.tagged_rules : key => rule if var.is_logging_account && lookup(rule.tags, local.logging_only_tag, false) && ! lookup(rule.tags, local.region_exclusion_tag, false) }
-  global_resource_rules = { for key, rule in local.tagged_rules : key => rule if var.is_global_resource_region && lookup(rule.tags, local.global_only_tag, false) && ! lookup(rule.tags, local.region_exclusion_tag, false) }
-  base_rules            = { for key, rule in local.tagged_rules : key => rule if(! lookup(rule.tags, local.logging_only_tag, false) && ! lookup(rule.tags, local.global_only_tag, false) && ! lookup(rule.tags, local.region_exclusion_tag, false)) }
+  logging_account_rules = { for key, rule in local.tagged_rules : key => rule if var.is_logging_account && lookup(rule.tags, local.logging_only_tag, false) && !lookup(rule.tags, local.region_exclusion_tag, false) }
+  global_resource_rules = { for key, rule in local.tagged_rules : key => rule if var.is_global_resource_region && lookup(rule.tags, local.global_only_tag, false) && !lookup(rule.tags, local.region_exclusion_tag, false) }
+  base_rules            = { for key, rule in local.tagged_rules : key => rule if(!lookup(rule.tags, local.logging_only_tag, false) && !lookup(rule.tags, local.global_only_tag, false) && !lookup(rule.tags, local.region_exclusion_tag, false)) }
   all_rules             = merge(local.base_rules, local.logging_account_rules, local.global_resource_rules)
 
   base_params = {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "aws_config_configuration_recorder_id" {
-  value       = join("", aws_config_configuration_recorder.recorder.*.id)
+  value       = join("", aws_config_configuration_recorder.recorder[*].id)
   description = "The ID of the AWS Config Recorder"
 }
 

--- a/test/src/examples_cis_test.go
+++ b/test/src/examples_cis_test.go
@@ -43,5 +43,5 @@ func TestExamplesCIS(t *testing.T) {
 
 	// Ensure we get the attribute included in the IDs
 	assert.Equal(t, fmt.Sprintf("eg-ue2-test-%s-config", randID), configRecorderID)
-	assert.Equal(t, fmt.Sprintf("eg-ue2-test-aws-config-%s",randID), bucketID)
+	assert.Equal(t, fmt.Sprintf("eg-ue2-test-%s-aws-config",randID), bucketID)
 }

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -44,6 +44,6 @@ func TestExamplesComplete(t *testing.T) {
 
 	// Ensure we get the attribute included in the IDs
 	assert.Equal(t, fmt.Sprintf("eg-ue2-test-%s-config", randID), configRecorderID)
-	assert.Equal(t, fmt.Sprintf("eg-ue2-test-aws-config-%s",randID), bucketID)
+	assert.Equal(t, fmt.Sprintf("eg-ue2-test-%s-aws-config",randID), bucketID)
 	assert.NotEqual(t, nil, iamRoleArn)
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 5.0"
     }
   }
 }


### PR DESCRIPTION
## what

Support AWS Provider V5
Linter fixes

## why

Maintenance

## references

https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0
