### PR TITLE
feat: add attributes in variables

### DIFF
--- a/context.tf
+++ b/context.tf
@@ -145,7 +145,7 @@ variable "delimiter" {
 
 variable "attributes" {
   type        = list(string)
-  default     = []
+  default     = ["config"]
   description = <<-EOT
     ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
     in the order they appear in the list. New attributes are appended to the

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ module "aws_config_label" {
   source  = "cloudposse/label/null"
   version = "0.25.0"
 
-  attributes = ["config"]
+  attributes = var.attributes
   context    = module.this.context
 }
 

--- a/main.tf
+++ b/main.tf
@@ -119,7 +119,7 @@ module "iam_role" {
   policy_description    = "AWS Config IAM policy"
   role_description      = "AWS Config IAM role"
 
-  attributes = ["config"]
+  attributes = var.iam_attributes
 
   context = module.this.context
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,3 @@
-variable "attributes" {
-  description = "ID element. Additional attributes (e.g. config) to add to id, in the order they appear in the list. New attributes are appended to the end of the list. The elements of the list are joined by the delimiter and treated as a single ID element."
-  type        = list(string)
-  default     = ["config"]
-}
-
 variable "s3_bucket_id" {
   description = "The id (name) of the S3 bucket used to store the configuration history"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,18 @@ variable "iam_role_arn" {
   type        = string
 }
 
+variable "iam_attributes" {
+  type        = list(string)
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+
+  default = ["config"]
+}
+
 variable "global_resource_collector_region" {
   description = "The region that collects AWS Config data for global resources such as IAM"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "attributes" {
+  description = "ID element. Additional attributes (e.g. config) to add to id, in the order they appear in the list. New attributes are appended to the end of the list. The elements of the list are joined by the delimiter and treated as a single ID element."
+  type        = list(string)
+  default     = ["config"]
+}
+
 variable "s3_bucket_id" {
   description = "The id (name) of the S3 bucket used to store the configuration history"
   type        = string


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Add attributes as variables instead of hard coded

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
I'm working in a big company and AWS Config has SCP that does not allow to delete existing AWS config recorder that has name `default`

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
