### PR TITLE
fix(main.tf): handle enabled boolean in manage_rules

### DIFF
--- a/examples/cis/outputs.tf
+++ b/examples/cis/outputs.tf
@@ -1,5 +1,6 @@
 output "enabled_rules" {
-  value = module.cis_rules.rules
+  value       = module.cis_rules.rules
+  description = "The output of the enabled CIS rules"
 }
 
 output "config_recorder_id" {

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ resource "aws_config_configuration_recorder_status" "recorder_status" {
 }
 
 resource "aws_config_config_rule" "rules" {
-  for_each   = module.this.enabled ? var.managed_rules : {}
+  for_each   = module.this.enabled ? { for k, v in var.managed_rules : k => v if v.enabled } : {}
   depends_on = [aws_config_configuration_recorder_status.recorder_status]
 
   name        = each.key

--- a/modules/cis-1-2-rules/outputs.tf
+++ b/modules/cis-1-2-rules/outputs.tf
@@ -1,3 +1,4 @@
 output "rules" {
-  value = local.enabled_rules
+  value       = local.enabled_rules
+  description = "Enable rules"
 }

--- a/modules/cis-1-2-rules/outputs.tf
+++ b/modules/cis-1-2-rules/outputs.tf
@@ -1,4 +1,4 @@
 output "rules" {
   value       = local.enabled_rules
-  description = "Enable rules"
+  description = "Enabled rules"
 }

--- a/modules/cis-1-2-rules/versions.tf
+++ b/modules/cis-1-2-rules/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.4.1"
+    }
+  }
+}

--- a/modules/conformance-pack/outputs.tf
+++ b/modules/conformance-pack/outputs.tf
@@ -1,3 +1,4 @@
 output "arn" {
-  value = aws_config_conformance_pack.default.arn
+  value       = aws_config_conformance_pack.default.arn
+  description = "ARN of the conformance pack"
 }


### PR DESCRIPTION
## what

use `enabled` boolean in `managed_rules` variable

## why

`aws_config_config_rule` resources were still being created despite `enabled` being set to `false`

