### PR TITLE
Upgrade AWS version to 6.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -266,7 +266,7 @@ resource "aws_config_aggregate_authorization" "child" {
   count = local.enabled && var.central_resource_collector_account != null && var.is_organization_aggregator == false ? 1 : 0
 
   account_id = var.central_resource_collector_account
-  region     = var.global_resource_collector_region
+  authorized_aws_region     = var.global_resource_collector_region
 
   tags = module.this.tags
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.38.0"
+      version = ">= 6.0"
     }
 
     http = {


### PR DESCRIPTION
## what

The region argument is deprecated in v6.0 and throws a warning

## why

To support AWS 6.0

## references

None