### PR TITLE
Flared/main

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Here is an example of using this module:
 | <a name="input_findings_notification_arn"></a> [findings\_notification\_arn](#input\_findings\_notification\_arn) | The ARN for an SNS topic to send findings notifications to. This is only used if create\_sns\_topic is false.<br/>If you want to send findings to an existing SNS topic, set the value of this to the ARN of the existing topic and set<br/>create\_sns\_topic to false. | `string` | `null` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable | `bool` | `false` | no |
 | <a name="input_global_resource_collector_region"></a> [global\_resource\_collector\_region](#input\_global\_resource\_collector\_region) | The region that collects AWS Config data for global resources such as IAM | `string` | n/a | yes |
+| <a name="region"></a> [region](#region) | Region where the resources will be managed. Defaults to the Region set in the provider configuration. | `string` | `null` | no |
 | <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | The ARN for an IAM Role AWS Config uses to make read or write requests to the delivery channel and to describe the<br/>AWS resources associated with the account. This is only used if create\_iam\_role is false.<br/><br/>If you want to use an existing IAM Role, set the value of this to the ARN of the existing topic and set<br/>create\_iam\_role to false.<br/><br/>See the AWS Docs for further information:<br/>http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html | `string` | `null` | no |
 | <a name="input_iam_role_organization_aggregator_arn"></a> [iam\_role\_organization\_aggregator\_arn](#input\_iam\_role\_organization\_aggregator\_arn) | The ARN for an IAM Role that AWS Config uses for the organization aggregator that fetches AWS config data from AWS accounts. <br/>This is only used if create\_organization\_aggregator\_iam\_role is false.<br/><br/>If you want to use an existing IAM Role, set the value of this to the ARN of the existing role and set<br/>create\_organization\_aggregator\_iam\_role to false.<br/><br/>See the AWS docs for further information:<br/>http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html | `string` | `null` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
@@ -303,15 +304,15 @@ Setup dependencies:
 
 To run tests:
 
-- Run all tests:  
+- Run all tests:
   ```sh
   atmos test run
   ```
-- Clean up test artifacts:  
+- Clean up test artifacts:
   ```sh
   atmos test clean
   ```
-- Explore additional test options:  
+- Explore additional test options:
   ```sh
   atmos test --help
   ```

--- a/main.tf
+++ b/main.tf
@@ -298,7 +298,7 @@ data "aws_partition" "current" {}
 locals {
   enabled = module.this.enabled && !contains(var.disabled_aggregation_regions, local.region)
 
-  region                                  = var.region != null ? var.region : data.aws_region.this.name
+  region                                  = var.region != null ? var.region : data.aws_region.this.region
   is_central_account                      = var.central_resource_collector_account == data.aws_caller_identity.this.account_id
   is_global_recorder_region               = var.global_resource_collector_region == local.region
   is_central_recorder_region              = local.is_central_account && local.is_global_recorder_region

--- a/main.tf
+++ b/main.tf
@@ -173,7 +173,7 @@ resource "aws_iam_role_policy_attachment" "config_policy_attachment" {
 }
 
 resource "aws_iam_role_policy_attachment" "organization_config_policy_attachment" {
-  count = module.this.enabled && local.create_iam_role && var.is_organization_aggregator ? 1 : 0
+  count = local.create_organization_aggregator_iam_role && local.is_central_recorder_region && var.is_organization_aggregator ? 1 : 0
 
   role       = module.iam_role_organization_aggregator[0].name
   policy_arn = data.aws_iam_policy.aws_config_organization_role.arn

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,8 @@ resource "aws_config_configuration_recorder" "recorder" {
   count    = module.this.enabled ? 1 : 0
   name     = module.aws_config_label.id
   role_arn = local.create_iam_role ? module.iam_role[0].arn : var.iam_role_arn
+  region   = local.region
+
   recording_group {
     all_supported                 = true
     include_global_resource_types = local.is_global_recorder_region
@@ -37,6 +39,7 @@ resource "aws_config_configuration_recorder" "recorder" {
 resource "aws_config_delivery_channel" "channel" {
   count          = module.this.enabled ? 1 : 0
   name           = module.aws_config_label.id
+  region         = local.region
   s3_bucket_name = var.s3_bucket_id
   s3_key_prefix  = var.s3_key_prefix
   sns_topic_arn  = local.findings_notification_arn
@@ -50,6 +53,7 @@ resource "aws_config_delivery_channel" "channel" {
 resource "aws_config_configuration_recorder_status" "recorder_status" {
   count      = module.this.enabled ? 1 : 0
   name       = aws_config_configuration_recorder.recorder[0].name
+  region     = local.region
   is_enabled = true
   depends_on = [aws_config_delivery_channel.channel]
 }
@@ -112,7 +116,7 @@ module "aws_config_findings_label" {
 #-----------------------------------------------------------------------------------------------------------------------
 # Optionally create IAM Roles
 #-----------------------------------------------------------------------------------------------------------------------
-# Create Optional IAM ROLE for S3 bucket and SNS  
+# Create Optional IAM ROLE for S3 bucket and SNS
 module "iam_role" {
   count   = module.this.enabled && local.create_iam_role ? 1 : 0
   source  = "cloudposse/iam-role/aws"
@@ -292,10 +296,11 @@ data "aws_caller_identity" "this" {}
 data "aws_partition" "current" {}
 
 locals {
-  enabled = module.this.enabled && !contains(var.disabled_aggregation_regions, data.aws_region.this.name)
+  enabled = module.this.enabled && !contains(var.disabled_aggregation_regions, local.region)
 
+  region                                  = var.region != null ? var.region : data.aws_region.this.name
   is_central_account                      = var.central_resource_collector_account == data.aws_caller_identity.this.account_id
-  is_global_recorder_region               = var.global_resource_collector_region == data.aws_region.this.name
+  is_global_recorder_region               = var.global_resource_collector_region == local.region
   child_resource_collector_accounts       = var.child_resource_collector_accounts != null ? var.child_resource_collector_accounts : []
   enable_notifications                    = module.this.enabled && (var.create_sns_topic || var.findings_notification_arn != null)
   create_sns_topic                        = module.this.enabled && var.create_sns_topic

--- a/main.tf
+++ b/main.tf
@@ -146,7 +146,7 @@ module "iam_role" {
 
 # Create Optional IAM ROLE for organization wide aggregator
 module "iam_role_organization_aggregator" {
-  count   = local.create_organization_aggregator_iam_role ? 1 : 0
+  count   = local.is_central_recorder_region && local.create_organization_aggregator_iam_role ? 1 : 0
   source  = "cloudposse/iam-role/aws"
   version = "0.19.0"
 
@@ -237,7 +237,7 @@ module "aws_config_aggregator_label" {
 resource "aws_config_configuration_aggregator" "this" {
   # Create the aggregator in the global recorder region of the central AWS Config account. This is usually the
   # "security" account
-  count = local.enabled && local.is_central_account && local.is_global_recorder_region ? 1 : 0
+  count = local.enabled && local.is_central_recorder_region ? 1 : 0
 
   name = module.aws_config_aggregator_label.id
 
@@ -301,6 +301,7 @@ locals {
   region                                  = var.region != null ? var.region : data.aws_region.this.name
   is_central_account                      = var.central_resource_collector_account == data.aws_caller_identity.this.account_id
   is_global_recorder_region               = var.global_resource_collector_region == local.region
+  is_central_recorder_region              = local.is_central_account && local.is_global_recorder_region
   child_resource_collector_accounts       = var.child_resource_collector_accounts != null ? var.child_resource_collector_accounts : []
   enable_notifications                    = module.this.enabled && (var.create_sns_topic || var.findings_notification_arn != null)
   create_sns_topic                        = module.this.enabled && var.create_sns_topic

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "storage_bucket_arn" {
 
 output "iam_role" {
   description = <<-DOC
-  IAM Role used to make read or write requests to the delivery channel and to describe the AWS resources associated with 
+  IAM Role used to make read or write requests to the delivery channel and to describe the AWS resources associated with
   the account.
   DOC
   value       = local.create_iam_role ? module.iam_role[0].arn : var.iam_role_arn
@@ -23,10 +23,10 @@ output "iam_role" {
 
 output "iam_role_organization_aggregator" {
   description = <<-DOC
-  IAM Role used to make read or write requests to the delivery channel and to describe the AWS resources associated with 
+  IAM Role used to make read or write requests to the delivery channel and to describe the AWS resources associated with
   the account.
   DOC
-  value       = local.create_organization_aggregator_iam_role ? module.iam_role_organization_aggregator[0].arn : var.iam_role_organization_aggregator_arn
+  value       = local.is_central_recorder_region && local.create_organization_aggregator_iam_role ? module.iam_role_organization_aggregator[0].arn : var.iam_role_organization_aggregator_arn
 }
 
 output "sns_topic" {

--- a/variables.tf
+++ b/variables.tf
@@ -91,7 +91,7 @@ variable "iam_role_arn" {
 
 variable "iam_role_organization_aggregator_arn" {
   description = <<-DOC
-    The ARN for an IAM Role that AWS Config uses for the organization aggregator that fetches AWS config data from AWS accounts. 
+    The ARN for an IAM Role that AWS Config uses for the organization aggregator that fetches AWS config data from AWS accounts.
     This is only used if create_organization_aggregator_iam_role is false.
 
     If you want to use an existing IAM Role, set the value of this to the ARN of the existing role and set
@@ -107,6 +107,12 @@ variable "iam_role_organization_aggregator_arn" {
 variable "global_resource_collector_region" {
   description = "The region that collects AWS Config data for global resources such as IAM"
   type        = string
+}
+
+variable "region" {
+  description = "Region where the resources will be managed. Defaults to the Region set in the provider configuration."
+  type        = string
+  default     = null
 }
 
 variable "central_resource_collector_account" {
@@ -146,7 +152,7 @@ variable "managed_rules" {
 
 variable "recording_mode" {
   description = <<-DOC
-    The mode for AWS Config to record configuration changes. 
+    The mode for AWS Config to record configuration changes.
 
     recording_frequency:
     The frequency with which AWS Config records configuration changes (service defaults to CONTINUOUS).
@@ -163,7 +169,7 @@ variable "recording_mode" {
         - DAILY
       resource_types:
         A list of resource types for which AWS Config records configuration changes. For example, AWS::EC2::Instance.
-    
+
     See the following for more information:
     https://docs.aws.amazon.com/config/latest/developerguide/stop-start-recorder.html
 


### PR DESCRIPTION
Add a `region` variables to setup AWS Config in a specific region. Useful to create all aws config from the same AWS provider.