### PR TITLE
fix: replace deprecated data.aws_region.this.name with data.aws_regio…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -266,7 +266,7 @@ resource "aws_config_aggregate_authorization" "child" {
   count = local.enabled && var.central_resource_collector_account != null && var.is_organization_aggregator == false ? 1 : 0
 
   account_id = var.central_resource_collector_account
-  region     = var.global_resource_collector_region
+  authorized_aws_region = var.global_resource_collector_region
 
   tags = module.this.tags
 }
@@ -279,7 +279,7 @@ resource "aws_config_aggregate_authorization" "central" {
   count = local.enabled && var.central_resource_collector_account == null && var.is_organization_aggregator == false ? 1 : 0
 
   account_id = data.aws_caller_identity.this.account_id
-  region     = var.global_resource_collector_region
+  authorized_aws_region = var.global_resource_collector_region
 
   tags = module.this.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -292,10 +292,10 @@ data "aws_caller_identity" "this" {}
 data "aws_partition" "current" {}
 
 locals {
-  enabled = module.this.enabled && !contains(var.disabled_aggregation_regions, data.aws_region.this.name)
+  enabled = module.this.enabled && !contains(var.disabled_aggregation_regions, data.aws_region.this.id)
 
   is_central_account                      = var.central_resource_collector_account == data.aws_caller_identity.this.account_id
-  is_global_recorder_region               = var.global_resource_collector_region == data.aws_region.this.name
+  is_global_recorder_region               = var.global_resource_collector_region == data.aws_region.this.id
   child_resource_collector_accounts       = var.child_resource_collector_accounts != null ? var.child_resource_collector_accounts : []
   enable_notifications                    = module.this.enabled && (var.create_sns_topic || var.findings_notification_arn != null)
   create_sns_topic                        = module.this.enabled && var.create_sns_topic


### PR DESCRIPTION
…n.this.id

- Replace deprecated 'name' attribute with 'id' attribute in data.aws_region
- Both attributes return the same value (AWS region name)
- Eliminates deprecation warnings in Terraform AWS provider
- Fixes lines 295 and 298 in main.tf

Resolves deprecation warnings:
- Warning: The attribute "name" is deprecated. Refer to the provider documentation for details.

## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
