### PR TITLE
feat: upgrade AWS provider to v6 and update all module dependencies

### DIFF
--- a/examples/cis/main.tf
+++ b/examples/cis/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "test_label" {
   source  = "cloudposse/label/null"
-  version = "0.22.1"
+  version = "0.25.0"
 
   attributes = ["test", "policy"]
   context    = module.this.context
@@ -66,7 +66,7 @@ module "cis_rules" {
 
 module "aws_config_storage" {
   source  = "cloudposse/config-storage/aws"
-  version = "1.0.0"
+  version = "1.0.2"
 
   force_destroy = var.force_destroy
   tags          = module.this.tags

--- a/examples/cis/versions.tf
+++ b/examples/cis/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -14,7 +14,7 @@ locals {
 
 module "aws_config_storage" {
   source  = "cloudposse/config-storage/aws"
-  version = "1.0.0"
+  version = "1.0.2"
 
   force_destroy = var.force_destroy
   tags          = module.this.tags

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     local = {
@@ -8,7 +8,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/examples/custom-rules/main.tf
+++ b/examples/custom-rules/main.tf
@@ -14,7 +14,7 @@ locals {
 
 module "aws_config_storage" {
   source  = "cloudposse/config-storage/aws"
-  version = "1.0.0"
+  version = "1.0.2"
 
   force_destroy = var.force_destroy
   tags          = module.this.tags

--- a/examples/custom-rules/versions.tf
+++ b/examples/custom-rules/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.38.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/examples/hipaa/main.tf
+++ b/examples/hipaa/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "aws_config_storage" {
   source  = "cloudposse/config-storage/aws"
-  version = "1.0.0"
+  version = "1.0.2"
 
   force_destroy = var.force_destroy
   tags          = module.this.tags
@@ -20,7 +20,7 @@ module "aws_config" {
   force_destroy                    = var.force_destroy
   s3_bucket_id                     = module.aws_config_storage.bucket_id
   s3_bucket_arn                    = module.aws_config_storage.bucket_arn
-  global_resource_collector_region = data.aws_region.current.name
+  global_resource_collector_region = data.aws_region.current.region
 
   context = module.this.context
 }

--- a/examples/hipaa/versions.tf
+++ b/examples/hipaa/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,7 @@ resource "aws_config_delivery_channel" "channel" {
   name           = module.aws_config_label.id
   s3_bucket_name = var.s3_bucket_id
   s3_key_prefix  = var.s3_key_prefix
+  s3_kms_key_arn = var.s3_kms_key_arn
   sns_topic_arn  = local.findings_notification_arn
 
   depends_on = [
@@ -66,6 +67,13 @@ resource "aws_config_config_rule" "rules" {
     source_identifier = each.value.identifier
   }
 
+  dynamic "evaluation_mode" {
+    for_each = each.value.evaluation_mode != null ? [each.value.evaluation_mode] : []
+    content {
+      mode = evaluation_mode.value
+    }
+  }
+
   input_parameters = length(each.value.input_parameters) > 0 ? jsonencode(each.value.input_parameters) : null
   tags             = merge(module.this.tags, each.value.tags)
 }
@@ -80,6 +88,13 @@ resource "aws_config_config_rule" "custom_lambda_rules" {
   source {
     owner             = "CUSTOM_LAMBDA"
     source_identifier = each.value.lambda_function_arn
+  }
+
+  dynamic "evaluation_mode" {
+    for_each = each.value.evaluation_mode != null ? [each.value.evaluation_mode] : []
+    content {
+      mode = evaluation_mode.value
+    }
   }
 
   input_parameters = length(each.value.input_parameters) > 0 ? jsonencode(each.value.input_parameters) : null
@@ -107,9 +122,17 @@ resource "aws_config_config_rule" "custom_policy_rules" {
     dynamic "custom_policy_details" {
       for_each = each.value.policy != null ? [1] : []
       content {
-        policy_runtime = each.value.policy_runtime
-        policy_text    = each.value.policy
+        policy_runtime            = each.value.policy_runtime
+        policy_text               = each.value.policy
+        enable_debug_log_delivery = each.value.enable_debug_log_delivery
       }
+    }
+  }
+
+  dynamic "evaluation_mode" {
+    for_each = each.value.evaluation_mode != null ? [each.value.evaluation_mode] : []
+    content {
+      mode = evaluation_mode.value
     }
   }
 
@@ -130,7 +153,7 @@ resource "aws_config_config_rule" "custom_policy_rules" {
 #-----------------------------------------------------------------------------------------------------------------------
 module "sns_topic" {
   source  = "cloudposse/sns-topic/aws"
-  version = "0.20.1"
+  version = "1.2.0"
   count   = module.this.enabled && local.create_sns_topic ? 1 : 0
 
   attributes = concat(module.this.attributes, ["config"])
@@ -171,7 +194,7 @@ module "aws_config_findings_label" {
 module "iam_role" {
   count   = module.this.enabled && local.create_iam_role ? 1 : 0
   source  = "cloudposse/iam-role/aws"
-  version = "0.19.0"
+  version = "1.0.0"
 
   principals = {
     "Service" = ["config.amazonaws.com"]
@@ -199,7 +222,7 @@ module "iam_role" {
 module "iam_role_organization_aggregator" {
   count   = local.create_organization_aggregator_iam_role ? 1 : 0
   source  = "cloudposse/iam-role/aws"
-  version = "0.19.0"
+  version = "1.0.0"
 
   principals = {
     "Service" = ["config.amazonaws.com"]
@@ -320,8 +343,8 @@ resource "aws_config_aggregate_authorization" "child" {
   # central_resource_collector_account
   count = local.enabled && var.central_resource_collector_account != null && var.is_organization_aggregator == false ? 1 : 0
 
-  account_id = var.central_resource_collector_account
-  region     = var.global_resource_collector_region
+  account_id            = var.central_resource_collector_account
+  authorized_aws_region = var.global_resource_collector_region
 
   tags = module.this.tags
 }
@@ -333,8 +356,8 @@ resource "aws_config_aggregate_authorization" "central" {
   # Authorize each region to send its data to the global_resource_collector_region
   count = local.enabled && var.central_resource_collector_account == null && var.is_organization_aggregator == false ? 1 : 0
 
-  account_id = data.aws_caller_identity.this.account_id
-  region     = var.global_resource_collector_region
+  account_id            = data.aws_caller_identity.this.account_id
+  authorized_aws_region = var.global_resource_collector_region
 
   tags = module.this.tags
 }

--- a/modules/cis-1-2-rules/main.tf
+++ b/modules/cis-1-2-rules/main.tf
@@ -1,5 +1,5 @@
 locals {
-  current_region = module.utils.region_az_alt_code_maps.to_fixed[data.aws_region.current.name]
+  current_region = module.utils.region_az_alt_code_maps.to_fixed[data.aws_region.current.region]
 
   file_rules      = module.aws_config_rules_yaml_config.map_configs
   rules_with_tags = { for k, rule in local.file_rules : k => rule if rule.tags != null }
@@ -56,5 +56,5 @@ data "aws_region" "current" {}
 
 module "utils" {
   source  = "cloudposse/utils/aws"
-  version = "1.0.0"
+  version = "1.4.0"
 }

--- a/modules/cis-1-2-rules/versions.tf
+++ b/modules/cis-1-2-rules/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.0.0"
     }
 
     http = {

--- a/modules/conformance-pack/versions.tf
+++ b/modules/conformance-pack/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.0.0"
     }
 
     http = {

--- a/variables.tf
+++ b/variables.tf
@@ -140,6 +140,7 @@ variable "managed_rules" {
     input_parameters = any
     tags             = map(string)
     enabled          = bool
+    evaluation_mode  = optional(string, null)
   }))
   default = {}
 }
@@ -187,6 +188,12 @@ variable "recording_mode" {
     }))
   })
   default = null
+}
+
+variable "s3_kms_key_arn" {
+  type        = string
+  description = "The ARN of the KMS key used to encrypt objects delivered by AWS Config to the S3 bucket. Must be in the same region as the S3 bucket."
+  default     = null
 }
 
 variable "s3_key_prefix" {
@@ -242,6 +249,7 @@ variable "custom_lambda_rules" {
     lambda_function_arn = string
     input_parameters    = optional(any, {})
     source_identifier   = optional(string, null)
+    evaluation_mode     = optional(string, null)
     scope = optional(object({
       compliance_resource_types = optional(list(string), [])
     }), null)
@@ -260,10 +268,12 @@ variable "custom_policy_rules" {
     https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_develop-rules_cfn-guard.html
   DOC
   type = map(object({
-    description      = string
-    policy           = optional(string, null) # Inline CFN Guard policy text
-    policy_runtime   = optional(string, "guard-2.x.x")
-    input_parameters = optional(any, {})
+    description               = string
+    policy                    = optional(string, null)
+    policy_runtime            = optional(string, "guard-2.x.x")
+    enable_debug_log_delivery = optional(bool, false)
+    evaluation_mode           = optional(string, null)
+    input_parameters          = optional(any, {})
     scope = optional(object({
       compliance_resource_types = optional(list(string), [])
     }), null)

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.38.0"
+      version = ">= 6.0.0"
     }
 
     http = {


### PR DESCRIPTION
## what

  - Bump AWS provider constraint from `>= 5.x` to `>= 6.0.0` across all `versions.tf` files (root, both submodules, all four examples)
  - Bump Terraform minimum version from `>= 1.0` to `>= 1.3` across all `versions.tf` files to formally align with `optional()` object type usage already present in the codebase
  - Fix breaking change: rename `region` → `authorized_aws_region` on both `aws_config_aggregate_authorization` resources (`child` and `central`)
  - Fix breaking change: replace removed `data.aws_region.*.name` attribute with `.region` in `examples/hipaa/main.tf` and `modules/cis-1-2-rules/main.tf`
  - Add `s3_kms_key_arn` argument to `aws_config_delivery_channel` and expose it as an optional variable for KMS encryption of delivered Config snapshots
  - Add `evaluation_mode` dynamic block to all three `aws_config_config_rule` resources (managed, custom Lambda, custom policy) and expose it as an optional variable
  - Add `enable_debug_log_delivery` to `custom_policy_details` block and expose it as an optional variable on `custom_policy_rules`
  - Update `cloudposse/sns-topic/aws`: `0.20.1` → `1.2.0`
  - Update `cloudposse/iam-role/aws`: `0.19.0` → `1.0.0`
  - Update `cloudposse/config-storage/aws`: `1.0.0` → `1.0.2` (all examples)
  - Update `cloudposse/utils/aws`: `1.0.0` → `1.4.0`
  - Update `cloudposse/label/null`: `0.22.1` → `0.25.0` in `examples/cis` (was the only stale reference)

  ## why

  - AWS provider v6 removed the `region` argument on `aws_config_aggregate_authorization` and the `name` attribute on the `aws_region` data source — both are hard failures without this fix
  - Terraform `>= 1.3` is the correct minimum since `optional()` in object type constraints (already used in `variables.tf`) was stabilized in that release
  - `evaluation_mode` enables opt-in **proactive** evaluation of Config rules before resources are deployed, a significant compliance feature added in recent provider versions
  - `s3_kms_key_arn` closes a gap where Config delivery to an encrypted S3 bucket had no native KMS argument wired through
  - `enable_debug_log_delivery` makes CFN Guard policy rule development easier by surfacing evaluation logs in CloudWatch
  - Module bumps bring in AWS provider v6 compatibility fixes and new features (SNS delivery status, IAM role managed policy ARN maps) from upstream CloudPosse modules

  ## references

  - [AWS Provider v6 Upgrade Guide](https://github.com/hashicorp/terraform-provider-aws/blob/main/website/docs/guides/version-6-upgrade.html.markdown)
  - [`aws_config_aggregate_authorization` — `authorized_aws_region`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_aggregate_authorization)
  - [`aws_region` data source — `region` attribute](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region)
  - [`aws_config_config_rule` — `evaluation_mode`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_config_rule)
  - [`aws_config_delivery_channel` — `s3_kms_key_arn`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_delivery_channel)
  - Close ticket #129 